### PR TITLE
Allow GameScale to be adjusted in-game using controller/keyboard

### DIFF
--- a/Data/Languages/eng.lng
+++ b/Data/Languages/eng.lng
@@ -69,6 +69,8 @@ settings_controls_X X
 settings_controls_Y Y
 settings_controls_Select Select
 settings_controls_Start Start
+settings_controls_L L
+settings_controls_R R
 settings_controls_reset Reset
 
 settings_graphics_header Video Settings

--- a/InGame/Controls/CButtons.cs
+++ b/InGame/Controls/CButtons.cs
@@ -16,7 +16,7 @@ namespace ProjectZ.InGame.Controls
         Y = 128,
         Select = 256,
         Start = 512,
-        //L = 1024,
-        //R = 2048
+        L = 1024,
+        R = 2048
     }
 }

--- a/InGame/Controls/ControlHandler.cs
+++ b/InGame/Controls/ControlHandler.cs
@@ -40,8 +40,8 @@ namespace ProjectZ.InGame.Controls
             ButtonDictionary.Add(CButtons.Y, new ButtonMapper(new[] { Keys.W }, new[] { Buttons.Y }));
             ButtonDictionary.Add(CButtons.Select, new ButtonMapper(new[] { Keys.Space }, new[] { Buttons.Back }));
             ButtonDictionary.Add(CButtons.Start, new ButtonMapper(new[] { Keys.Enter }, new[] { Buttons.Start }));
-            //buttonDictionary.Add(CButtons.L, new ButtonMapper(new[] { Keys.NumPad4 }, new[] { Buttons.LeftShoulder }));
-            //buttonDictionary.Add(CButtons.R, new ButtonMapper(new[] { Keys.NumPad6 }, new[] { Buttons.RightShoulder }));
+            ButtonDictionary.Add(CButtons.L, new ButtonMapper(new[] { Keys.OemMinus }, new[] { Buttons.LeftShoulder }));
+            ButtonDictionary.Add(CButtons.R, new ButtonMapper(new[] { Keys.OemPlus }, new[] { Buttons.RightShoulder }));
         }
 
         public static void SaveButtonMaps(SaveManager saveManager)

--- a/InGame/Overlay/OverlayManager.cs
+++ b/InGame/Overlay/OverlayManager.cs
@@ -143,9 +143,9 @@ namespace ProjectZ.InGame.Overlay
 
             // toggle map scale
             if (_currentMenuState == MenuState.None && ControlHandler.ButtonPressed(CButtons.L))
-                HandleGameScaleChanged(GameScaleDirection.Smaller);
+                UpdateGameScale(GameScaleDirection.Smaller);
             if (_currentMenuState == MenuState.None && ControlHandler.ButtonPressed(CButtons.R))
-                HandleGameScaleChanged(GameScaleDirection.Bigger);
+                UpdateGameScale(GameScaleDirection.Bigger);
 
             if (_currentMenuState == MenuState.None)
             {
@@ -470,7 +470,7 @@ namespace ProjectZ.InGame.Overlay
             _currentMenuState = newState;
         }
 
-        private static void HandleGameScaleChanged(GameScaleDirection scaleDirection)
+        private static void UpdateGameScale(GameScaleDirection scaleDirection)
         {
             var newScale = GameSettings.GameScale + (short)scaleDirection;
             if (newScale >= -1 && newScale <= 11)

--- a/InGame/Overlay/OverlayManager.cs
+++ b/InGame/Overlay/OverlayManager.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 using ProjectZ.Base;
 using ProjectZ.Base.UI;
 using ProjectZ.InGame.Controls;
+using ProjectZ.InGame.Interface;
 using ProjectZ.InGame.Overlay.Sequences;
 using ProjectZ.InGame.Pages;
 using ProjectZ.InGame.Things;
@@ -21,6 +22,12 @@ namespace ProjectZ.InGame.Overlay
         enum MenuState
         {
             None, Menu, Inventory, PhotoBook, GameSequence
+        }
+
+        enum GameScaleDirection: short
+        {
+            Smaller = -1, 
+            Bigger = 1
         }
 
         private MenuState _currentMenuState = MenuState.None;
@@ -133,6 +140,12 @@ namespace ProjectZ.InGame.Overlay
             if ((_currentMenuState == MenuState.None || _currentMenuState == MenuState.Inventory) &&
                 ControlHandler.ButtonPressed(CButtons.Select) && !DisableInventoryToggle && !_hideHud && !TextboxOverlay.IsOpen)
                 ToggleState(MenuState.Inventory);
+
+            // toggle map scale
+            if (_currentMenuState == MenuState.None && ControlHandler.ButtonPressed(CButtons.L))
+                HandleGameScaleChanged(GameScaleDirection.Smaller);
+            if (_currentMenuState == MenuState.None && ControlHandler.ButtonPressed(CButtons.R))
+                HandleGameScaleChanged(GameScaleDirection.Bigger);
 
             if (_currentMenuState == MenuState.None)
             {
@@ -455,6 +468,16 @@ namespace ProjectZ.InGame.Overlay
             _fadeDir = 1;
             _lastMenuState = _currentMenuState;
             _currentMenuState = newState;
+        }
+
+        private static void HandleGameScaleChanged(GameScaleDirection scaleDirection)
+        {
+            var newScale = GameSettings.GameScale + (short)scaleDirection;
+            if (newScale >= -1 && newScale <= 11)
+            {
+                GameSettings.GameScale = newScale;
+                Game1.ScaleSettingChanged = true;
+            }
         }
 
         public void CloseOverlay()

--- a/InGame/Pages/ControlSettingsPage.cs
+++ b/InGame/Pages/ControlSettingsPage.cs
@@ -23,7 +23,7 @@ namespace ProjectZ.InGame.Pages
             var controlLayout = new InterfaceListLayout { Size = new Point(width, height), Selectable = true };
 
             controlLayout.AddElement(new InterfaceLabel(Resources.GameHeaderFont, "settings_controls_header",
-                new Point(width - 50, (int)(height * Values.MenuHeaderSize)), new Point(0, 0)));
+                new Point(width - 50, (int)(height * Values.MenuHeaderSize)), new Point(0, -10)));
 
             var controllerHeight = (int)(height * Values.MenuContentSize);
 

--- a/InGame/Pages/GraphicSettingsPage.cs
+++ b/InGame/Pages/GraphicSettingsPage.cs
@@ -8,6 +8,7 @@ namespace ProjectZ.InGame.Pages
 {
     class GraphicSettingsPage : InterfacePage
     {
+        private readonly InterfaceSlider _gameScaleSlider;
         private readonly InterfaceListLayout _bottomBar;
         private readonly InterfaceListLayout _toggleFullscreen;
 
@@ -25,14 +26,15 @@ namespace ProjectZ.InGame.Pages
 
             var contentLayout = new InterfaceListLayout { Size = new Point(width, (int)(height * Values.MenuContentSize)), Selectable = true, ContentAlignment = InterfaceElement.Gravities.Top };
 
-            contentLayout.AddElement(new InterfaceSlider(Resources.GameFont, "settings_graphics_game_scale",
+            _gameScaleSlider = new InterfaceSlider(Resources.GameFont, "settings_graphics_game_scale",
                 buttonWidth, new Point(1, 2), -1, 11, 1, GameSettings.GameScale + 1,
                 number =>
                 {
                     GameSettings.GameScale = number;
                     Game1.ScaleSettingChanged = true;
                 })
-            { SetString = number => GameSettings.GameScale == 11 ? "auto" : " x" + (number < 1 ? "1/" + (2 - number) : number.ToString()) });
+            { SetString = number => GameSettings.GameScale == 11 ? "auto" : " x" + (number < 1 ? "1/" + (2 - number) : number.ToString()) };
+            contentLayout.AddElement(_gameScaleSlider);
 
             //contentLayout.AddElement(_uiScaleSlider = new InterfaceSlider(Resources.GameFont, "settings_graphics_ui_scale",
             //    buttonWidth, new Point(1, 2), 1, Game1.ScreenScale + 1, 1, GameSettings.UiScale - 1,
@@ -92,6 +94,8 @@ namespace ProjectZ.InGame.Pages
 
             //UpdateScaleSlider();
 
+            UpdateGameScaleSlider();
+
             // close the page
             if (ControlHandler.ButtonPressed(CButtons.B))
                 Game1.UiPageManager.PopPage();
@@ -113,6 +117,12 @@ namespace ProjectZ.InGame.Pages
             var toggle = ((InterfaceToggle)_toggleFullscreen.Elements[1]);
             if (toggle.ToggleState != GameSettings.IsFullscreen)
                 toggle.SetToggle(GameSettings.IsFullscreen);
+        }
+
+        private void UpdateGameScaleSlider()
+        {
+            var currentScale = GameSettings.GameScale;
+            _gameScaleSlider.CurrentStep = currentScale + 1;
         }
 
         //private void UpdateScaleSlider()


### PR DESCRIPTION
## Description
This PR adds the ability to modify the game scale in-game via the keyboard/controller.

Keys default to L/R buttons on controller, +/- buttons on keyboard.

Inspired from a [Vinesauce stream](https://youtu.be/rOs1CgRiL14?t=854), where Vinny mentioned it should be added in an update.

## Items of note
It looks like at some point L/R were intended to be used for something, but were commented out of the code.

Additionally, I've had to adjust the margins of the Control Settings screen in order to fit the new key rows. This is less noticeable in the in-game Settings menu - however, in the Settings menu found at the Main Menu the "Reset" and "Back" buttons were being pushed off screen by the two new button rows.

## Future Improvements
Having some kind of toast or UI indication appear on screen when a player adjusts the scale would be nice.

## Screenshots
### Control Settings (Main Menu)
![Menu - Pre-game](https://github.com/ihm-tswow/Links-Awakening-DX-HD/assets/1912017/ee8100bc-8689-462d-ace8-d4c5401cf3a8)

### Control Settings (In-Game)
![Menu - In-game](https://github.com/ihm-tswow/Links-Awakening-DX-HD/assets/1912017/178d706f-8f70-4cfc-a503-dbde7c121abc)

### In-Game Footage
https://github.com/ihm-tswow/Links-Awakening-DX-HD/assets/1912017/1c275b2e-1620-49cb-a6f8-64b3d36f798a

