### PR TITLE
Quit button

### DIFF
--- a/Data/Languages/eng.lng
+++ b/Data/Languages/eng.lng
@@ -4,6 +4,7 @@ main_menu_new_game New Game
 main_menu_settings Settings
 main_menu_copy Copy
 main_menu_erase Erase
+main_menu_quit Quit
 
 main_menu_delete_confirmation_header Erase Save?
 main_menu_delete_confirmation_header_yes Yes

--- a/InGame/Pages/MainMenuPage.cs
+++ b/InGame/Pages/MainMenuPage.cs
@@ -183,6 +183,19 @@ namespace ProjectZ.InGame.Pages
                         Game1.UiPageManager.ChangePage(typeof(SettingsPage));
                     }
                 });
+
+                var smallButtonLayout2 = new InterfaceGravityLayout { Size = new Point(smallButtonWidth, buttonHeight) };
+                smallButtonLayout2.AddElement(new InterfaceLabel("main_menu_quit") { Gravity = InterfaceElement.Gravities.Center });
+                _menuBottomBar.AddElement(new InterfaceButton
+                {
+                    Size = new Point(smallButtonWidth, buttonHeight),
+                    InsideElement = smallButtonLayout2,
+                    Margin = new Point(smallButtonMargin, 2),
+                    ClickFunction = element =>
+                    {
+                        Game1.UiPageManager.ChangePage(typeof(QuitGamePage));
+                    }
+                });
             }
 
             // main layout

--- a/InGame/Pages/PageManager.cs
+++ b/InGame/Pages/PageManager.cs
@@ -61,6 +61,7 @@ namespace ProjectZ.InGame.Pages
             AddPage(new GameMenuPage(_width, _height));
             AddPage(new ExitGamePage(_width, _height));
             AddPage(new GameOverPage(_width, _height));
+            AddPage(new QuitGamePage(_width, _height));
         }
 
         public virtual void Update(GameTime gameTime)

--- a/InGame/Pages/QuitGamePage.cs
+++ b/InGame/Pages/QuitGamePage.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using Microsoft.Xna.Framework;
+using ProjectZ.InGame.Controls;
+using ProjectZ.InGame.Interface;
+using ProjectZ.InGame.Things;
+
+namespace ProjectZ.InGame.Pages
+{
+    class QuitGamePage : InterfacePage
+    {
+        public QuitGamePage(int width, int height)
+        {
+            var margin = 6;
+
+            // yes no layout
+            var yesNoLayoutInside = new InterfaceListLayout() { Size = new Point(150 + margin * 2, 55), Selectable = true };
+            yesNoLayoutInside.AddElement(new InterfaceLabel(Resources.GameHeaderFont, "game_menu_exit_header", new Point(150, 30), new Point(1, 2)) { TextColor = Color.White });
+            var hLayout = new InterfaceListLayout() { Size = new Point(150, 25), Margin = new Point(0, 2), Selectable = true, HorizontalMode = true };
+            hLayout.AddElement(new InterfaceButton(new Point(74, 25), Point.Zero, "game_menu_exit_yes", OnClickYes) { Margin = new Point(2, 0) });
+            hLayout.AddElement(new InterfaceButton(new Point(74, 25), Point.Zero, "game_menu_exit_no", OnClickNo) { Margin = new Point(2, 0) });
+            yesNoLayoutInside.AddElement(hLayout);
+
+            var yesNoLayout = new InterfaceListLayout() { Size = new Point(width, height), Selectable = true };
+            yesNoLayout.AddElement(yesNoLayoutInside);
+
+            PageLayout = yesNoLayout;
+        }
+
+        public override void Update(CButtons pressedButtons, GameTime gameTime)
+        {
+            base.Update(pressedButtons, gameTime);
+
+            // close the page
+            if (ControlHandler.ButtonPressed(CButtons.B))
+                Game1.UiPageManager.PopPage();
+        }
+
+        public override void OnLoad(Dictionary<string, object> intent)
+        {
+            // select the "Back to Game" button
+            PageLayout.Deselect(false);
+            PageLayout.Select(InterfaceElement.Directions.Right, false);
+        }
+
+        public void OnClickNo(InterfaceElement element)
+        {
+            // go to the previous page
+            Game1.UiPageManager.PopPage();
+        }
+
+        public void OnClickYes(InterfaceElement element)
+        {
+            // quit the game
+            Application.Exit();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a quit button to the main menu.

This was done to make it easier to quit the game in an environment where you don't have access to a keyboard, e.g. a SteamDeck or a PC running Batocera.

![](https://github.com/ihm-tswow/Links-Awakening-DX-HD/assets/2441011/606638ce-4fa6-44f8-a895-4144ccd92448)
![](https://github.com/ihm-tswow/Links-Awakening-DX-HD/assets/2441011/63d9ca04-0d37-4f63-b5c2-e19cde693829)
